### PR TITLE
docs: add default pgAdmin login credentials to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ cp .env.example .env & make up
 
 You can login to pgAdmin at `http://localhost:8080` to see the Postgres database. The host name for registering a new server is `postgres`, and the username and password are `alphatrion` and `alphatr1on`, respectively.
 
+**Note:**  
+To log in to the pgAdmin web interface itself (before adding a server),  
+use the default credentials defined in `docker-compose.yaml`:  
+**Email:** `alphatrion@inftyai.com`  
+**Password:** `alphatr1on`
+
 ### Run a Sample Experiment
 
 Below is a simple example demonstrating how to create an experiment and log performance metrics.


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates the README to include the default pgAdmin web login credentials (`alphatrion@inftyai.com` / `alphatr1on`) from the `docker-compose.yaml` file.

This helps new contributors log into pgAdmin successfully during local setup, as the README previously only mentioned the URL without the credentials.

### Which issue(s) this PR fixes
None — just a small documentation improvement.
