### PR TITLE
Fixed issue where bedrock output unexpected attribute format

### DIFF
--- a/alphatrion/tracing/cost_enrichment_processor.py
+++ b/alphatrion/tracing/cost_enrichment_processor.py
@@ -55,7 +55,16 @@ class CostEnrichmentProcessor(SpanProcessor):
 
             # Extract token usage
             attributes = span.attributes
-            provider = determine_provider(str(attributes.get("gen_ai.openai.api_base")))
+            # OpenAI SDK populates the `gen_ai.openai.api_base` with base URL
+            # whereas Bedrock SDK either only populates the `gen_ai.system` with "AWS"
+            # or the `gen_ai.provider.name` with "aws.bedrock"
+            provider = determine_provider(
+                str(
+                    attributes.get("gen_ai.openai.api_base")
+                    or attributes.get("gen_ai.system")
+                    or attributes.get("gen_ai.provider.name")
+                )
+            )
             model = str(
                 attributes.get("gen_ai.request.model")
                 or attributes.get("gen_ai.response.model", "")


### PR DESCRIPTION
#### What this PR does / why we need it
When using Alphatrion to track token usage with Bedrock (using the `boto3` API), the provider wasn't being detected properly. This fixes that issue.

#### Which issue(s) this PR fixes
Fixes #255

#### Special notes for your reviewer
None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
